### PR TITLE
Restore calculation type handling

### DIFF
--- a/c-sharp/src/main/java/com/regnosys/rosetta/generator/c_sharp/util/CSharpTranslator.xtend
+++ b/c-sharp/src/main/java/com/regnosys/rosetta/generator/c_sharp/util/CSharpTranslator.xtend
@@ -15,7 +15,8 @@ class CSharpTranslator {
 				
 	def toCSharpBasicType(String typename) {
 		switch typename {
-			case 'string':
+			case 'string',
+			case 'calculation':
 				'string'
 			case 'int':
 				'int'

--- a/c-sharp/src/test/java/com/regnosys/rosetta/generator/c_sharp/CSharpModelObjectGeneratorTest.xtend
+++ b/c-sharp/src/test/java/com/regnosys/rosetta/generator/c_sharp/CSharpModelObjectGeneratorTest.xtend
@@ -553,6 +553,62 @@ class CSharpModelObjectGeneratorTest {
     }
     
     @Test
+    def void shouldGenerateCalculationType() {
+        val c_sharp = '''
+			type Foo:
+			     attr calculation (0..1)
+        '''.generateCSharp
+
+        val types = c_sharp.get('Types.cs')
+        
+        assertEquals('''
+	        // This file is auto-generated from the ISDA Common Domain Model, do not edit.
+	        //
+	        // Version: test
+	        //
+	        [assembly: Rosetta.Lib.Attributes.CdmVersion("test")]
+	        
+	        #nullable enable // Allow nullable reference types
+	        
+	        namespace Org.Isda.Cdm
+	        {
+	            using System.Collections.Generic;
+	        
+	            using Newtonsoft.Json;
+	            using Newtonsoft.Json.Converters;
+	        
+	            using NodaTime;
+	        
+	            using Rosetta.Lib;
+	            using Rosetta.Lib.Attributes;
+	            using Rosetta.Lib.Meta;
+	            using Rosetta.Lib.Validation;
+	        
+	            using Org.Isda.Cdm.Meta;
+	            using Org.Isda.Cdm.MetaFields;
+	            using _MetaFields = Org.Isda.Cdm.MetaFields.MetaFields;
+	            
+	            public class Foo : AbstractRosettaModelObject<Foo>
+	            {
+	                private static readonly IRosettaMetaData<Foo> metaData = new FooMeta();
+	                
+	                [JsonConstructor]
+	                public Foo(string? attr)
+	                {
+	                    Attr = attr;
+	                }
+	                
+	                /// <inheritdoc />
+	                [JsonIgnore]
+	                public override IRosettaMetaData<Foo> MetaData => metaData;
+	                
+	                public string? Attr { get; }
+	            }
+	        }
+        '''.toString, types.toString)
+    }
+
+    @Test
     def void shouldGenerateTypesExtends() {
 
          val c_sharp = '''

--- a/daml/src/main/java/com/regnosys/rosetta/generator/daml/util/DamlTranslator.xtend
+++ b/daml/src/main/java/com/regnosys/rosetta/generator/daml/util/DamlTranslator.xtend
@@ -18,7 +18,8 @@ class DamlTranslator {
 	static def toDamlBasicType(String typename) {
 		switch typename {
 			case 'String',
-			case 'string':
+			case 'string',
+			case 'calculation':
 				'Text'
 			case 'int':
 				'Int'

--- a/daml/src/test/java/com/regnosys/rosetta/generator/daml/DamlModelObjectGeneratorTest.xtend
+++ b/daml/src/test/java/com/regnosys/rosetta/generator/daml/DamlModelObjectGeneratorTest.xtend
@@ -118,6 +118,7 @@ class DamlModelObjectGeneratorTest {
 			    timeAttr time (1..1)
 				zonedDateTimeAttr zonedDateTime (1..1)
 				dateTimeAttr dateTime (1..1)
+				calculationAttr calculation (1..1)
 		'''.generateDaml
 		
 		val fileContent = classes.get("Org/Isda/Cdm/Classes.daml").toString
@@ -147,6 +148,7 @@ class DamlModelObjectGeneratorTest {
 			  timeAttr : Text
 			  zonedDateTimeAttr : ZonedDateTime
 			  dateTimeAttr : DateTime
+			  calculationAttr : Text
 			    deriving (Eq, Ord, Show)
 			
 	    '''.toString, fileContent)

--- a/golang/src/main/java/com/regnosys/rosetta/generator/golang/util/GolangTranslator.xtend
+++ b/golang/src/main/java/com/regnosys/rosetta/generator/golang/util/GolangTranslator.xtend
@@ -5,7 +5,8 @@ class GolangTranslator {
 	static def toGOBasicType(String typename) {
 		switch typename {
 			case 'String',				
-			case 'string':
+			case 'string',
+			case 'calculation':
 				'string'								 			
 			case 'int':
 				'int'

--- a/golang/src/test/java/com/regnosys/rosetta/generator/golang/GolangModelObjectGeneratorTest.xtend
+++ b/golang/src/test/java/com/regnosys/rosetta/generator/golang/GolangModelObjectGeneratorTest.xtend
@@ -158,6 +158,34 @@ class GolangModelObjectGeneratorTest {
 
 	}	
 	
+    @Test
+    def void shouldGenerateCalculationType() {
+        val golang = '''
+			type Foo:
+			     attr calculation (0..1)
+        '''.generateGolang
+
+		val types = golang.get('org_isda_cdm/types.go').toString
+        
+        assertEquals('''
+	        package org_isda_cdm
+	        
+	        /**
+	         * This file is auto-generated from the ISDA Common Domain Model, do not edit.
+	         * Version: test
+	         */
+	        
+	        import "time"
+	        import . "org_isda_cdm_metafields";
+	          
+	        
+	        type Foo struct {
+	          Attr string;
+	        }
+	          
+        '''.toString, types.toString)
+    }
+
 	@Test	
 	def void shouldGenerateMetaTypes() {
 		val golang = '''

--- a/json-schema/src/main/java/com/regnosys/rosetta/generator/jsonschema/JsonSchemaTranslator.xtend
+++ b/json-schema/src/main/java/com/regnosys/rosetta/generator/jsonschema/JsonSchemaTranslator.xtend
@@ -10,7 +10,8 @@ class JsonSchemaTranslator {
 			case 'time',
 			case 'date',
 			case 'dateTime',
-			case 'zonedDateTime':
+			case 'zonedDateTime',
+			case 'calculation':
 				'string'
 			case 'int':
 				'integer'

--- a/kotlin/src/main/java/com/regnosys/rosetta/generator/kotlin/util/KotlinTranslator.xtend
+++ b/kotlin/src/main/java/com/regnosys/rosetta/generator/kotlin/util/KotlinTranslator.xtend
@@ -9,7 +9,8 @@ class KotlinTranslator {
 
     def String toKotlinBasicType(String typename) {
         switch typename {
-            case 'string':
+            case 'string',
+            case 'calculation':
             	'String'
             case 'int': 'Int'
             case 'time': 'String'

--- a/kotlin/src/test/java/com/regnosys/rosetta/generator/kotlin/KotlinModelObjectGeneratorTest.xtend
+++ b/kotlin/src/test/java/com/regnosys/rosetta/generator/kotlin/KotlinModelObjectGeneratorTest.xtend
@@ -127,6 +127,41 @@ class KotlinModelObjectGeneratorTest {
     }
     
     @Test
+    def void shouldGenerateCalculationType() {
+        val kotlin = '''
+			type Foo:
+			     attr calculation (0..1)
+        '''.generateKotlin
+
+		val types = kotlin.get('Types.kt').toString
+        
+        assertEquals('''
+	        /**
+	         * This file is auto-generated from the ISDA Common Domain Model, do not edit.
+	         * Version: test
+	         */
+	        package org.isda.cdm.kotlin
+	        
+	        import kotlinx.serialization.*
+	        
+	        /**
+	        * Basic Date implementation
+	        */
+	        @Serializable
+	        class Date (
+	          val year: Int,
+	          val month: Int,
+	          val day: Int
+	        )
+	        
+	        @Serializable
+	        open class Foo (
+	          var attr: String? = null
+	        )
+        '''.toString, types.toString)
+    }
+
+    @Test
     def void shouldGenerateTypesExtends() {
         val kotlin = '''
 			type TestType extends TestType2:

--- a/scala/src/main/java/com/regnosys/rosetta/generator/scala/util/ScalaTranslator.xtend
+++ b/scala/src/main/java/com/regnosys/rosetta/generator/scala/util/ScalaTranslator.xtend
@@ -14,7 +14,8 @@ class ScalaTranslator {
 				
 	static def toScalaBasicType(String typename) {
 		switch typename {
-			case 'string':
+			case 'string',
+			case 'calculation':
 				'String'
 			case 'int':
 				'Int'

--- a/scala/src/test/java/com/regnosys/rosetta/generator/scala/ScalaModelObjectGeneratorTest.xtend
+++ b/scala/src/test/java/com/regnosys/rosetta/generator/scala/ScalaModelObjectGeneratorTest.xtend
@@ -148,6 +148,34 @@ class ScalaModelObjectGeneratorTest {
 
 
 
+    @Test
+    def void shouldGenerateCalculationType() {
+        val scala = '''
+			type Foo:
+			     attr calculation (0..1)
+        '''.generateScala
+
+		val types = scala.get('Types.scala').toString
+        
+        assertEquals('''
+	        /**
+	          * This file is auto-generated from the ISDA Common Domain Model, do not edit.
+	          * Version: test
+	          */
+	        package org.isda.cdm
+	        
+	        import com.fasterxml.jackson.core.`type`.TypeReference
+	        import com.fasterxml.jackson.module.scala.JsonScalaEnumeration
+	        import com.fasterxml.jackson.databind.annotation.JsonDeserialize
+	        
+	        import org.isda.cdm.metafields._
+	        
+	        case class Foo(attr: Option[String]) {
+	        }
+	        
+        '''.toString, types.toString)
+    }
+
 	@Test
 	def void shouldGenerateTypesExtends() {
 		val scala = '''

--- a/typescript/src/main/java/com/regnosys/rosetta/generator/typescript/util/TypescriptTranslator.xtend
+++ b/typescript/src/main/java/com/regnosys/rosetta/generator/typescript/util/TypescriptTranslator.xtend
@@ -5,7 +5,8 @@ class TypescriptTranslator {
 	static def toTSBasicType(String typename) {
 		switch typename {
 			case 'String',
-			case 'string':
+			case 'string',
+			case 'calculation':
 				'string'
 			case 'int':
 				'number'

--- a/typescript/src/test/java/com/regnosys/rosetta/generator/typescript/TypescriptModelObjectGeneratorTest.xtend
+++ b/typescript/src/test/java/com/regnosys/rosetta/generator/typescript/TypescriptModelObjectGeneratorTest.xtend
@@ -137,6 +137,32 @@ class TypescriptModelObjectGeneratorTest {
 
 
 
+    @Test
+    def void shouldGenerateCalculationType() {
+        val typescript = '''
+			type Foo:
+			     attr calculation (0..1)
+        '''.generateTypescript
+
+		val types = typescript.get('types.ts').toString
+        
+        assertEquals('''
+	        /**
+	         * This file is auto-generated from the ISDA Common Domain Model, do not edit.
+	         * Version: test
+	         */
+	        
+	        import { ReferenceWithMeta, FieldWithMeta, MetaFields } from './metatypes';
+	        import {
+	            } from './enums';
+	        
+	        export interface Foo {
+	          attr?: string;
+	        }
+	          
+        '''.toString, types.toString)
+    }
+
 	@Test
 	def void shouldGenerateTypesExtends() {
 		val typescript = '''


### PR DESCRIPTION
## Summary

The `calculation` type alias is being restored in the DSL (finos/rune-dsl#1253), since it is still used in production models as a placeholder for potential future usage.

This reverts only the calculation-specific parts of the deprecated-syntax deletion (#527):

- `case 'calculation'` restored in the C#, DAML, Golang, JSON-schema, Kotlin, Scala and TypeScript translators
- `shouldGenerateCalculationType` tests restored (C#, Golang, Kotlin, Scala, TypeScript) and the `calculationAttr` lines in the DAML test

The `productType`/`eventType` aliases and the enum-synonym cleanups stay deleted.

## Verification

Built locally with `mvnd install -pl c-sharp,daml,golang,json-schema,kotlin,scala,typescript -am -Drune.dsl.version=0.0.0.main-SNAPSHOT` against a local DSL snapshot that includes the calculation restore — BUILD SUCCESS, all tests pass.

⚠️ Note: CI on this PR will fail against DSL `10.0.0-dev.15` (no `calculation` alias there); it should be merged together with (or after) the DSL version bump to the release containing finos/rune-dsl#1253.

🤖 Generated with [Claude Code](https://claude.com/claude-code)