### PR TITLE
Bump to rune-dsl 10.1.0 and bundle 12.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -143,8 +143,8 @@
         <gpg.passphrase>configured-by-release-profile</gpg.passphrase>
         <stagingTimeoutInMinutes>20</stagingTimeoutInMinutes>
 
-        <rune.dsl.version>10.0.0-dev.17</rune.dsl.version>
-        <rosetta.bundle.version>12.0.0-dev.25</rosetta.bundle.version>
+        <rune.dsl.version>10.0.0-dev.18</rune.dsl.version>
+        <rosetta.bundle.version>12.0.0-dev.26</rosetta.bundle.version>
 
         <xtext.version>2.38.0</xtext.version>
         <guice.version>6.0.0</guice.version>

--- a/pom.xml
+++ b/pom.xml
@@ -143,7 +143,7 @@
         <gpg.passphrase>configured-by-release-profile</gpg.passphrase>
         <stagingTimeoutInMinutes>20</stagingTimeoutInMinutes>
 
-        <rune.dsl.version>10.0.0-dev.20</rune.dsl.version>
+        <rune.dsl.version>10.0.0-dev.21</rune.dsl.version>
         <rosetta.bundle.version>12.0.0-dev.28</rosetta.bundle.version>
 
         <xtext.version>2.38.0</xtext.version>


### PR DESCRIPTION
Part of STORY-1810. Aligns rosetta-code-generators with the new bundle:
- `rune.dsl.version` → `10.0.0-dev.18`
- `rosetta.bundle.version` → `12.0.0-dev.26`

Builds green under the `regnosys` profile (intra-bundle SNAPSHOT). No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)