### PR TITLE
Bump rune-dsl to 10.0.0-dev.20 and bundle to 12.0.0-dev.28

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -143,7 +143,7 @@
         <gpg.passphrase>configured-by-release-profile</gpg.passphrase>
         <stagingTimeoutInMinutes>20</stagingTimeoutInMinutes>
 
-        <rune.dsl.version>10.0.0-dev.19</rune.dsl.version>
+        <rune.dsl.version>10.0.0-dev.20</rune.dsl.version>
         <rosetta.bundle.version>12.0.0-dev.28</rosetta.bundle.version>
 
         <xtext.version>2.38.0</xtext.version>

--- a/pom.xml
+++ b/pom.xml
@@ -143,7 +143,7 @@
         <gpg.passphrase>configured-by-release-profile</gpg.passphrase>
         <stagingTimeoutInMinutes>20</stagingTimeoutInMinutes>
 
-        <rune.dsl.version>10.0.0-dev.17</rune.dsl.version>
+        <rune.dsl.version>10.0.0-dev.19</rune.dsl.version>
         <rosetta.bundle.version>12.0.0-dev.27</rosetta.bundle.version>
 
         <xtext.version>2.38.0</xtext.version>

--- a/pom.xml
+++ b/pom.xml
@@ -144,7 +144,7 @@
         <stagingTimeoutInMinutes>20</stagingTimeoutInMinutes>
 
         <rune.dsl.version>10.0.0-dev.19</rune.dsl.version>
-        <rosetta.bundle.version>12.0.0-dev.27</rosetta.bundle.version>
+        <rosetta.bundle.version>12.0.0-dev.28</rosetta.bundle.version>
 
         <xtext.version>2.38.0</xtext.version>
         <guice.version>6.0.0</guice.version>


### PR DESCRIPTION
## Changes
- `rune.dsl.version`: 10.0.0-dev.17 -> **10.0.0-dev.20**
- `rosetta.bundle.version`: 12.0.0-dev.27 -> **12.0.0-dev.28** (next bundle release)

The incompatible changes (the `Rosetta*Configuration` -> `Rune*Configuration` config API rename) were introduced in dev.18; dev.19 and dev.20 are backwards-compatible patches on top. No source changes needed in code-generators beyond the version bumps.
