### PR TITLE
Update rune-dsl to 10.1.1 and rosetta bundle to 12.1.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -143,8 +143,8 @@
         <gpg.passphrase>configured-by-release-profile</gpg.passphrase>
         <stagingTimeoutInMinutes>20</stagingTimeoutInMinutes>
 
-        <rune.dsl.version>10.1.0</rune.dsl.version>
-        <rosetta.bundle.version>12.1.7</rosetta.bundle.version>
+        <rune.dsl.version>10.1.1</rune.dsl.version>
+        <rosetta.bundle.version>12.1.8</rosetta.bundle.version>
 
         <xtext.version>2.38.0</xtext.version>
         <guice.version>6.0.0</guice.version>


### PR DESCRIPTION
Update the `rune-dsl` dependency to the 10.1.1 patch release, and bump the rosetta bundle (`rune-common`) to the next patch version 12.1.8.