### PR TITLE
[11.x.x] - Don't generate override meta when subtype already has it

### DIFF
--- a/c-sharp/pom.xml
+++ b/c-sharp/pom.xml
@@ -48,12 +48,12 @@
 
 	<dependencies>
 		<dependency>
-			<groupId>com.regnosys.rosetta</groupId>
-			<artifactId>com.regnosys.rosetta.lib</artifactId>
+			<groupId>org.finos.rune</groupId>
+			<artifactId>rune-runtime</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>com.regnosys.rosetta</groupId>
-			<artifactId>com.regnosys.rosetta</artifactId>
+			<groupId>org.finos.rune</groupId>
+			<artifactId>rune-lang</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>com.regnosys</groupId>
@@ -73,8 +73,8 @@
 		</dependency>
 
 		<dependency>
-			<groupId>com.regnosys.rosetta</groupId>
-			<artifactId>com.regnosys.rosetta.tests</artifactId>
+			<groupId>org.finos.rune</groupId>
+			<artifactId>rune-testing</artifactId>
             <scope>test</scope>
 		</dependency>
 		<dependency>

--- a/csv/pom.xml
+++ b/csv/pom.xml
@@ -51,12 +51,12 @@
     
   	<dependencies>
 		<dependency>
-			<groupId>com.regnosys.rosetta</groupId>
-			<artifactId>com.regnosys.rosetta</artifactId>
+			<groupId>org.finos.rune</groupId>
+			<artifactId>rune-lang</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>com.regnosys.rosetta</groupId>
-			<artifactId>com.regnosys.rosetta.lib</artifactId>
+			<groupId>org.finos.rune</groupId>
+			<artifactId>rune-runtime</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>com.regnosys.rosetta.code-generators</groupId>

--- a/daml/pom.xml
+++ b/daml/pom.xml
@@ -48,8 +48,8 @@
 
 	<dependencies>
 		<dependency>
-			<groupId>com.regnosys.rosetta</groupId>
-			<artifactId>com.regnosys.rosetta</artifactId>
+			<groupId>org.finos.rune</groupId>
+			<artifactId>rune-lang</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>com.regnosys</groupId>
@@ -65,8 +65,8 @@
 		</dependency>
 
 		<dependency>
-			<groupId>com.regnosys.rosetta</groupId>
-			<artifactId>com.regnosys.rosetta.tests</artifactId>
+			<groupId>org.finos.rune</groupId>
+			<artifactId>rune-testing</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/default-cdm-generators/pom.xml
+++ b/default-cdm-generators/pom.xml
@@ -60,14 +60,14 @@
 	                            <version>${project.version}</version>
 	                        </dependency>
 	                        <dependency>
-	                            <groupId>com.regnosys.rosetta</groupId>
-	                            <artifactId>com.regnosys.rosetta</artifactId>
-	                            <version>${rosetta.dsl.version}</version>
+	                            <groupId>org.finos.rune</groupId>
+	                            <artifactId>rune-lang</artifactId>
+	                            <version>${rune.dsl.version}</version>
 	                        </dependency>
 	                        <dependency>
-	                            <groupId>com.regnosys.rosetta</groupId>
-	                            <artifactId>com.regnosys.rosetta.lib</artifactId>
-	                            <version>${rosetta.dsl.version}</version>
+	                            <groupId>org.finos.rune</groupId>
+	                            <artifactId>rune-runtime</artifactId>
+	                            <version>${rune.dsl.version}</version>
 	                        </dependency>
 	                    </dependencies>
                     </plugin>
@@ -78,8 +78,8 @@
 
 	<dependencies>
 		<dependency>
-			<groupId>com.regnosys.rosetta</groupId>
-			<artifactId>com.regnosys.rosetta</artifactId>
+			<groupId>org.finos.rune</groupId>
+			<artifactId>rune-lang</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>com.regnosys.rosetta.code-generators</groupId>

--- a/excel/pom.xml
+++ b/excel/pom.xml
@@ -49,12 +49,12 @@
     
 	<dependencies>
 		<dependency>
-			<groupId>com.regnosys.rosetta</groupId>
-			<artifactId>com.regnosys.rosetta</artifactId>
+			<groupId>org.finos.rune</groupId>
+			<artifactId>rune-lang</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>com.regnosys.rosetta</groupId>
-			<artifactId>com.regnosys.rosetta.lib</artifactId>
+			<groupId>org.finos.rune</groupId>
+			<artifactId>rune-runtime</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>com.regnosys.rosetta.code-generators</groupId>

--- a/golang/pom.xml
+++ b/golang/pom.xml
@@ -48,12 +48,12 @@
 
     <dependencies>
    		<dependency>
-			<groupId>com.regnosys.rosetta</groupId>
-			<artifactId>com.regnosys.rosetta.lib</artifactId>
+			<groupId>org.finos.rune</groupId>
+			<artifactId>rune-runtime</artifactId>
 		</dependency>
             <dependency>
-            <groupId>com.regnosys.rosetta</groupId>
-            <artifactId>com.regnosys.rosetta</artifactId>
+            <groupId>org.finos.rune</groupId>
+            <artifactId>rune-lang</artifactId>
         </dependency>
         <dependency>
             <groupId>com.regnosys</groupId>
@@ -69,8 +69,8 @@
         </dependency>
 
         <dependency>
-            <groupId>com.regnosys.rosetta</groupId>
-            <artifactId>com.regnosys.rosetta.tests</artifactId>
+            <groupId>org.finos.rune</groupId>
+            <artifactId>rune-testing</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/json-schema/pom.xml
+++ b/json-schema/pom.xml
@@ -57,12 +57,12 @@
 
 
         <dependency>
-			<groupId>com.regnosys.rosetta</groupId>
-			<artifactId>com.regnosys.rosetta.lib</artifactId>
+			<groupId>org.finos.rune</groupId>
+			<artifactId>rune-runtime</artifactId>
 		</dependency>
         <dependency>
-            <groupId>com.regnosys.rosetta</groupId>
-            <artifactId>com.regnosys.rosetta</artifactId>
+            <groupId>org.finos.rune</groupId>
+            <artifactId>rune-lang</artifactId>
         </dependency>
         <dependency>
             <groupId>com.regnosys</groupId>
@@ -78,8 +78,8 @@
         </dependency>
 
         <dependency>
-            <groupId>com.regnosys.rosetta</groupId>
-            <artifactId>com.regnosys.rosetta.tests</artifactId>
+            <groupId>org.finos.rune</groupId>
+            <artifactId>rune-testing</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/kotlin/pom.xml
+++ b/kotlin/pom.xml
@@ -48,12 +48,12 @@
 
   <dependencies>
     <dependency>
-      <groupId>com.regnosys.rosetta</groupId>
-      <artifactId>com.regnosys.rosetta.lib</artifactId>
+      <groupId>org.finos.rune</groupId>
+      <artifactId>rune-runtime</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.regnosys.rosetta</groupId>
-      <artifactId>com.regnosys.rosetta</artifactId>
+      <groupId>org.finos.rune</groupId>
+      <artifactId>rune-lang</artifactId>
     </dependency>
     <dependency>
       <groupId>com.regnosys</groupId>
@@ -69,8 +69,8 @@
 	</dependency>
 
     <dependency>
-      <groupId>com.regnosys.rosetta</groupId>
-      <artifactId>com.regnosys.rosetta.tests</artifactId>
+      <groupId>org.finos.rune</groupId>
+      <artifactId>rune-testing</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/kotlin/src/main/java/com/regnosys/rosetta/generator/kotlin/object/KotlinModelObjectGenerator.xtend
+++ b/kotlin/src/main/java/com/regnosys/rosetta/generator/kotlin/object/KotlinModelObjectGenerator.xtend
@@ -90,8 +90,9 @@ class KotlinModelObjectGenerator {
     private def generateAttributes(Data c) {
         val t = c.buildRDataType
         val attrs = t.allAttributes.filter[enclosingType?.EObject == c && parentAttribute === null]
+        val superTypeRequiresMeta = c.superType !== null && c.superType.buildRDataType.requiresMetaFields
         '''
-        «FOR attribute : attrs SEPARATOR ",\n"»«generateAttribute(c, attribute)»«ENDFOR»«IF t.requiresMetaFields»«IF !attrs.isEmpty»,
+        «FOR attribute : attrs SEPARATOR ",\n"»«generateAttribute(c, attribute)»«ENDFOR»«IF t.requiresMetaFields && !superTypeRequiresMeta»«IF !attrs.isEmpty»,
         «ENDIF»var meta: MetaFields? = null«ENDIF»
         '''
     }

--- a/kotlin/src/test/java/com/regnosys/rosetta/generator/kotlin/KotlinModelObjectGeneratorTest.xtend
+++ b/kotlin/src/test/java/com/regnosys/rosetta/generator/kotlin/KotlinModelObjectGeneratorTest.xtend
@@ -442,6 +442,38 @@ class KotlinModelObjectGeneratorTest {
 			: Foo()'''))
 	}
 
+    @Test
+    def void shouldGenerateOverrideMetaWhenSubtypeExtendsSupertypeWithMeta() {
+        val kotlin = '''
+            metaType scheme string
+            metaType key string
+
+            type SuperType:
+                [metadata key]
+                attr1 string (0..1)
+
+            type SubType extends SuperType:
+                [metadata key]
+                attr2 string (0..1)
+        '''.generateKotlin
+
+        val types = kotlin.get('Types.kt').toString
+        // println(types)
+        assertTrue(types.contains('''
+            @Serializable
+            open class SubType (
+              var attr2: String? = null
+            )
+            : SuperType()'''))
+
+        assertTrue(types.contains('''
+            @Serializable
+            open class SuperType (
+              var attr1: String? = null,
+              var meta: MetaFields? = null
+            )'''))
+    }
+
     def generateKotlin(CharSequence model) {
         val m = model.parseRosettaWithNoErrors
 		val resourceSet = m.eResource.resourceSet

--- a/pom.xml
+++ b/pom.xml
@@ -143,7 +143,7 @@
         <gpg.passphrase>configured-by-release-profile</gpg.passphrase>
         <stagingTimeoutInMinutes>20</stagingTimeoutInMinutes>
 
-        <rosetta.dsl.version>9.84.0</rosetta.dsl.version>
+        <rune.dsl.version>9.85.0</rune.dsl.version>
         <rosetta.bundle.version>11.124.0</rosetta.bundle.version>
 
         <xtext.version>2.38.0</xtext.version>
@@ -271,20 +271,20 @@
             </dependency>
 
             <dependency>
-                <groupId>com.regnosys.rosetta</groupId>
-                <artifactId>com.regnosys.rosetta</artifactId>
-                <version>${rosetta.dsl.version}</version>
+                <groupId>org.finos.rune</groupId>
+                <artifactId>rune-lang</artifactId>
+                <version>${rune.dsl.version}</version>
             </dependency>
             <dependency>
-                <groupId>com.regnosys.rosetta</groupId>
-                <artifactId>com.regnosys.rosetta.tests</artifactId>
-                <version>${rosetta.dsl.version}</version>
+                <groupId>org.finos.rune</groupId>
+                <artifactId>rune-testing</artifactId>
+                <version>${rune.dsl.version}</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
-                <groupId>com.regnosys.rosetta</groupId>
-                <artifactId>com.regnosys.rosetta.lib</artifactId>
-                <version>${rosetta.dsl.version}</version>
+                <groupId>org.finos.rune</groupId>
+                <artifactId>rune-runtime</artifactId>
+                <version>${rune.dsl.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.regnosys</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -144,7 +144,7 @@
         <stagingTimeoutInMinutes>20</stagingTimeoutInMinutes>
 
         <rosetta.dsl.version>9.84.0</rosetta.dsl.version>
-        <rosetta.bundle.version>11.123.0</rosetta.bundle.version>
+        <rosetta.bundle.version>11.124.0</rosetta.bundle.version>
 
         <xtext.version>2.38.0</xtext.version>
         <guice.version>6.0.0</guice.version>

--- a/sample/pom.xml
+++ b/sample/pom.xml
@@ -19,12 +19,12 @@
 
 	<dependencies>
 		<dependency>
-			<groupId>com.regnosys.rosetta</groupId>
-			<artifactId>com.regnosys.rosetta</artifactId>
+			<groupId>org.finos.rune</groupId>
+			<artifactId>rune-lang</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>com.regnosys.rosetta</groupId>
-			<artifactId>com.regnosys.rosetta.lib</artifactId>
+			<groupId>org.finos.rune</groupId>
+			<artifactId>rune-runtime</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>com.regnosys.rosetta.code-generators</groupId>

--- a/scala/pom.xml
+++ b/scala/pom.xml
@@ -48,12 +48,12 @@
 
     <dependencies>
    		<dependency>
-			<groupId>com.regnosys.rosetta</groupId>
-			<artifactId>com.regnosys.rosetta.lib</artifactId>
+			<groupId>org.finos.rune</groupId>
+			<artifactId>rune-runtime</artifactId>
 		</dependency>
         <dependency>
-            <groupId>com.regnosys.rosetta</groupId>
-            <artifactId>com.regnosys.rosetta</artifactId>
+            <groupId>org.finos.rune</groupId>
+            <artifactId>rune-lang</artifactId>
         </dependency>
         <dependency>
             <groupId>com.regnosys</groupId>
@@ -69,8 +69,8 @@
         </dependency>
 
         <dependency>
-            <groupId>com.regnosys.rosetta</groupId>
-            <artifactId>com.regnosys.rosetta.tests</artifactId>
+            <groupId>org.finos.rune</groupId>
+            <artifactId>rune-testing</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/test-helper/pom.xml
+++ b/test-helper/pom.xml
@@ -52,21 +52,21 @@
 	<dependencyManagement>
 		<dependencies>
 			<dependency>
-	        	<groupId>com.regnosys.rosetta</groupId>
-                <artifactId>com.regnosys.rosetta.tests</artifactId>
-                <version>${rosetta.dsl.version}</version>
+	        	<groupId>org.finos.rune</groupId>
+                <artifactId>rune-testing</artifactId>
+                <version>${rune.dsl.version}</version>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>
 
     <dependencies>
         <dependency>
-            <groupId>com.regnosys.rosetta</groupId>
-            <artifactId>com.regnosys.rosetta</artifactId>
+            <groupId>org.finos.rune</groupId>
+            <artifactId>rune-lang</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.regnosys.rosetta</groupId>
-            <artifactId>com.regnosys.rosetta.tests</artifactId>
+            <groupId>org.finos.rune</groupId>
+            <artifactId>rune-testing</artifactId>
         </dependency>
         <dependency>
             <groupId>org.eclipse.xtext</groupId>

--- a/typescript/pom.xml
+++ b/typescript/pom.xml
@@ -48,12 +48,12 @@
 
     <dependencies>
    		<dependency>
-			<groupId>com.regnosys.rosetta</groupId>
-			<artifactId>com.regnosys.rosetta.lib</artifactId>
+			<groupId>org.finos.rune</groupId>
+			<artifactId>rune-runtime</artifactId>
 		</dependency>
             <dependency>
-            <groupId>com.regnosys.rosetta</groupId>
-            <artifactId>com.regnosys.rosetta</artifactId>
+            <groupId>org.finos.rune</groupId>
+            <artifactId>rune-lang</artifactId>
         </dependency>
         <dependency>
             <groupId>com.regnosys</groupId>
@@ -69,8 +69,8 @@
         </dependency>
 
         <dependency>
-            <groupId>com.regnosys.rosetta</groupId>
-            <artifactId>com.regnosys.rosetta.tests</artifactId>
+            <groupId>org.finos.rune</groupId>
+            <artifactId>rune-testing</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Backports a self-contained generator fix from `main` to `11.x.x`, prepares the bundle version for the next release, and migrates the DSL dependency to the finos-published coordinates.

## Backported
- #532 — Don't generate override meta when subtype already has it (Kotlin generator + test; no pom/coordinate change). Local `mvn -pl kotlin -am clean install` (Java 21): KotlinModelObjectGeneratorTest 10/10.

## Bundle version
- Bump `rosetta.bundle.version` `11.123.0` → `11.124.0` (the next 11.x.x minor) so this backport ships in that coordinated bundle release. Note: resolves against `com.regnosys:rosetta-common:11.124.0`, which is published as part of the 11.124.0 bundle release, so a standalone build won't resolve it until then.

## DSL dependency migration to org.finos.rune 9.85.0
- Replace the legacy `com.regnosys.rosetta:*:9.84.0` DSL artifacts with the finos-published `org.finos.rune:*:9.85.0` coordinates across all poms (same DSL 9.x major):
  - `com.regnosys.rosetta.lib` → `rune-runtime`
  - `com.regnosys.rosetta` → `rune-lang`
  - `com.regnosys.rosetta.tests` → `rune-testing`
  - groupId `com.regnosys.rosetta` → `org.finos.rune`
  - property `rosetta.dsl.version` (`9.84.0`) → `rune.dsl.version` (`9.85.0`)
- The repo's own `com.regnosys.rosetta.code-generators` coordinates are unchanged.
- Builds green against DSL 9.85.0 on Java 21 (`mvn -nsu clean install`, all module tests pass); a standalone build still needs the coordinated `rosetta-common` bundle (see note above).

`11.x.x` stays on the DSL 9.x line; DSL-10 bumps are excluded.
