### PR TITLE
Update DSL to 10.2.2 and bundle version to 12.3.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -143,8 +143,8 @@
         <gpg.passphrase>configured-by-release-profile</gpg.passphrase>
         <stagingTimeoutInMinutes>20</stagingTimeoutInMinutes>
 
-        <rune.dsl.version>10.2.1</rune.dsl.version>
-        <rosetta.bundle.version>12.3.0</rosetta.bundle.version>
+        <rune.dsl.version>10.2.2</rune.dsl.version>
+        <rosetta.bundle.version>12.3.1</rosetta.bundle.version>
 
         <xtext.version>2.38.0</xtext.version>
         <guice.version>6.0.0</guice.version>


### PR DESCRIPTION
Updates the Rune DSL dependency to 10.2.2 and sets the next bundle version to 12.3.1.

This picks up the DSL 10.2.2 release (fix for NPE when reading an attribute overridden to zero cardinality, finos/rune-dsl#1322).