### PR TITLE
fix: Windows compatibility — line-ending tolerant generator tests

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+# Sources and expectation files are stored with LF and generator tests compare
+# generated output against fixtures, so check them out with LF on every
+# platform (overrides core.autocrlf on Windows).
+* text=auto eol=lf
+# C# template resources are shipped verbatim to .NET consumers, where CRLF is
+# conventional; keep them exactly as committed.
+c-sharp/src/main/resources/** -text

--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -19,8 +19,10 @@ jobs:
         java-version: '21'
         distribution: temurin
         cache: maven
+    # The regnosys profile resolves bundle dependencies as snapshots, like the
+    # internal CI does; the pom default points at the next (unreleased) bundle
     - name: Build with Maven
-      run: mvn -B clean package
+      run: mvn -B clean package -P regnosys
 
   build-on-windows:
     name: Maven Build on Windows
@@ -34,5 +36,7 @@ jobs:
         java-version: '21'
         distribution: temurin
         cache: maven
+    # The regnosys profile resolves bundle dependencies as snapshots, like the
+    # internal CI does; the pom default points at the next (unreleased) bundle
     - name: Build with Maven
-      run: mvn -B clean package
+      run: mvn -B clean package -P regnosys

--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -1,0 +1,38 @@
+name: PR Checks
+
+on:
+  pull_request:
+
+# Cancel previous jobs
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-on-ubuntu:
+    name: Maven Build on Ubuntu
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v6
+    - uses: actions/setup-java@v5
+      with:
+        java-version: '21'
+        distribution: temurin
+        cache: maven
+    - name: Build with Maven
+      run: mvn -B clean package
+
+  build-on-windows:
+    name: Maven Build on Windows
+    runs-on: windows-latest
+    steps:
+    - name: Enable git long paths
+      run: git config --system core.longpaths true
+    - uses: actions/checkout@v6
+    - uses: actions/setup-java@v5
+      with:
+        java-version: '21'
+        distribution: temurin
+        cache: maven
+    - name: Build with Maven
+      run: mvn -B clean package

--- a/c-sharp/src/main/java/com/regnosys/rosetta/generator/c_sharp/util/CSharpModelGeneratorUtil.xtend
+++ b/c-sharp/src/main/java/com/regnosys/rosetta/generator/c_sharp/util/CSharpModelGeneratorUtil.xtend
@@ -28,7 +28,7 @@ class CSharpModelGeneratorUtil {
      '''
 
      private static def splitDefinition(String definition) '''
-           «FOR line : definition.split("\n")»
+           «FOR line : definition.split("\r?\n")»
            /// «StringEscapeUtils.escapeXml11(line)»
            «ENDFOR»
      '''

--- a/json-schema/src/test/java/com/regnosys/rosetta/generator/jsonschema/JsonSchemaGenerationTest.java
+++ b/json-schema/src/test/java/com/regnosys/rosetta/generator/jsonschema/JsonSchemaGenerationTest.java
@@ -74,7 +74,7 @@ public class JsonSchemaGenerationTest {
     @MethodSource("load")
     void runTest(String generatedFileName, String expectedFile, String actualFile) {
     	LOGGER.info("Testing schema generation, file: {}", generatedFileName);
-        assertEquals(expectedFile, actualFile);
+        assertEquals(normaliseLineEndings(expectedFile), normaliseLineEndings(actualFile));
         validateJsonSchema(actualFile);
     }
 
@@ -118,5 +118,11 @@ public class JsonSchemaGenerationTest {
         for (ValidationMessage assertion : assertions) {
             fail(assertion.toString());
         }
+    }
+
+    private static String normaliseLineEndings(String text) {
+        // Xtend templates emit the platform line separator, so normalise both
+        // sides before comparing against the committed LF expectation files
+        return text == null ? null : text.replace("\r\n", "\n");
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -143,7 +143,7 @@
         <gpg.passphrase>configured-by-release-profile</gpg.passphrase>
         <stagingTimeoutInMinutes>20</stagingTimeoutInMinutes>
 
-        <rune.dsl.version>10.2.2</rune.dsl.version>
+        <rune.dsl.version>10.2.3</rune.dsl.version>
         <rosetta.bundle.version>12.3.1</rosetta.bundle.version>
 
         <xtext.version>2.38.0</xtext.version>

--- a/pom.xml
+++ b/pom.xml
@@ -144,7 +144,7 @@
         <stagingTimeoutInMinutes>20</stagingTimeoutInMinutes>
 
         <rune.dsl.version>10.2.3</rune.dsl.version>
-        <rosetta.bundle.version>12.3.1</rosetta.bundle.version>
+        <rosetta.bundle.version>12.3.2</rosetta.bundle.version>
 
         <xtext.version>2.38.0</xtext.version>
         <guice.version>6.0.0</guice.version>


### PR DESCRIPTION
## Summary

Part of a cross-repo Windows-compatibility effort (see REGnosys/rosetta-products#6854 and finos/rune-common#675).

- **`JsonSchemaGenerationTest`**: normalise line endings before comparing generated schemas with the committed expectation files. Xtend rich-string templates emit the runtime platform separator, and the json-schema templates additionally embed literal `\n` separators, so on Windows the output has mixed CRLF/LF and the exact comparison always failed.
- **`CSharpModelGeneratorUtil`**: split definitions on `\r?\n` so generated C# doc comments don't retain a trailing CR when a `.rosetta` input is checked out with CRLF.
- **`.gitattributes` pinning LF** for sources and expectation files. The C# template resources under `c-sharp/src/main/resources` are excluded (`-text`): they ship verbatim to .NET consumers, where CRLF is conventional, and are stored CRLF today.

Note on conventions: all generators here emit the platform line separator via Xtend templates (generated output is not byte-deterministic across OS). Most tests are immune because they compare Xtend output against Xtend literals; only the json-schema test compares against committed files. Pinning the Xtend `StringConcatenation` delimiter to `\n` would make generator output deterministic, but that changes emitted code on Windows and is left for a separate discussion (same position as taken in rune-dsl).

Verified with a full local `mvn clean install` (all modules green) against the rune-common/rune-testing Windows branches; rosetta-components rebuilt green on top.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
