### PR TITLE
Bump bundle version to 11.124.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -144,7 +144,7 @@
         <stagingTimeoutInMinutes>20</stagingTimeoutInMinutes>
 
         <rune.dsl.version>9.85.1</rune.dsl.version>
-        <rosetta.bundle.version>11.124.1</rosetta.bundle.version>
+        <rosetta.bundle.version>11.124.3</rosetta.bundle.version>
 
         <xtext.version>2.38.0</xtext.version>
         <guice.version>6.0.0</guice.version>


### PR DESCRIPTION
Patch bundle release of the 11.x line carrying the backport of REGnosys/rosetta-components#877.

🤖 Generated with [Claude Code](https://claude.com/claude-code)