### PR TITLE
Update rosetta.bundle.version to 12.6.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -144,7 +144,7 @@
         <stagingTimeoutInMinutes>20</stagingTimeoutInMinutes>
 
         <rune.dsl.version>10.3.0</rune.dsl.version>
-        <rosetta.bundle.version>12.5.1</rosetta.bundle.version>
+        <rosetta.bundle.version>12.6.1</rosetta.bundle.version>
 
         <xtext.version>2.38.0</xtext.version>
         <guice.version>6.0.0</guice.version>


### PR DESCRIPTION
Bundle version bump ahead of releasing **12.6.1**, which picks up the line-ending backwards-compatibility fixes merged today:

- finos/rune-common#687 — shared `LineEndings.normalise` utility
- finos/rune-testing#368 — normalise line endings when reading expectation files

This is the release that unblocks the CDM upgrade: it is on the 12.x line, and the raw `assertEquals` against a CRLF-checked-out expectation file was the failure we reproduced.

Note the pom was on 12.5.1 while 12.6.0 is already tagged, so the next patch is **12.6.1** rather than 12.5.2.

`depcheck` will be red on this PR until 12.6.1 is actually published — the CVE workflow runs a plain `mvn` that resolves `rosetta-common` at the bundle version, which does not exist until the release runs. Same as previous bundle bumps; it is not a required check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)