### PR TITLE
[11.x.x] - Update rosetta.bundle.version to 11.125.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -144,7 +144,7 @@
         <stagingTimeoutInMinutes>20</stagingTimeoutInMinutes>
 
         <rune.dsl.version>9.85.1</rune.dsl.version>
-        <rosetta.bundle.version>11.125.0</rosetta.bundle.version>
+        <rosetta.bundle.version>11.125.1</rosetta.bundle.version>
 
         <xtext.version>2.38.0</xtext.version>
         <guice.version>6.0.0</guice.version>


### PR DESCRIPTION
Bundle version bump ahead of releasing **11.125.1**, which picks up the line-ending backwards-compatibility fixes merged today:

- finos/rune-common#688 — shared `LineEndings.normalise` utility
- finos/rune-testing#369 — normalise line endings when reading expectation files

11.125.0 (released earlier today) carries the Windows fixes but not the compatibility fix for them, so this patch completes that line.

`depcheck` will be red on this PR until 11.125.1 is actually published — the CVE workflow runs a plain `mvn` that resolves `rosetta-common` at the bundle version, which does not exist until the release runs. Same as the 11.125.0 bump; it is not a required check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)