### PR TITLE
Activate regnosys profile in CVE scanning workflow

### DIFF
--- a/.github/workflows/cve-scanning.yml
+++ b/.github/workflows/cve-scanning.yml
@@ -59,6 +59,7 @@ jobs:
           NVD_API_KEY: ${{ secrets.NVD_API_KEY }}
         run: |
           mvn -B org.owasp:dependency-check-maven:12.2.2:update-only \
+            -P regnosys \
             -DdataDirectory="${PWD}/.dependency-check-data" \
             -DnvdApiKeyEnvironmentVariable=NVD_API_KEY \
             -DnvdApiDelay=6000 \
@@ -75,10 +76,13 @@ jobs:
           key: nvd-data-${{ steps.date.outputs.date }}
       # Scans against whatever NVD data is already cached (autoUpdate=false),
       # so this step stays fast and isn't blocked by a flaky/slow sync.
+      # The regnosys profile resolves bundle dependencies as snapshots, like the
+      # internal CI does; the pom default points at the next (unreleased) bundle.
       - name: CVE scanning
         id: cve-scanning
         run: |
           mvn -B org.owasp:dependency-check-maven:12.2.2:aggregate \
+            -P regnosys \
             -Dname="Rosetta Code Generators" \
             -DdataDirectory="${PWD}/.dependency-check-data" \
             -DautoUpdate=false \


### PR DESCRIPTION
## Summary
- The CVE scanning workflow's `mvn` steps (NVD update and dependency-check scan) ran without `-P regnosys`, so they resolved bundle dependencies against the pom's default `rosetta.bundle.version` (the next, unreleased bundle) instead of the snapshot version used by `check-pr.yml` and internal CI.
- Adds `-P regnosys` to both `mvn` invocations so the CVE scan builds/scans against the same bundle version as the rest of CI.

## Test plan
- [ ] Confirm the `CVE Scanning` workflow run on this PR resolves bundle dependencies as the `0.0.0.main-SNAPSHOT` version rather than the pom default