### PR TITLE
[11.x.x] Update to DSL 9.88.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -143,8 +143,8 @@
         <gpg.passphrase>configured-by-release-profile</gpg.passphrase>
         <stagingTimeoutInMinutes>20</stagingTimeoutInMinutes>
 
-        <rune.dsl.version>9.87.0</rune.dsl.version>
-        <rosetta.bundle.version>11.127.0</rosetta.bundle.version>
+        <rune.dsl.version>9.88.0</rune.dsl.version>
+        <rosetta.bundle.version>11.128.0</rosetta.bundle.version>
 
         <xtext.version>2.38.0</xtext.version>
         <guice.version>6.0.0</guice.version>


### PR DESCRIPTION
Bump `rune.dsl.version` to 9.88.0 and `rosetta.bundle.version` to 11.128.0.