### PR TITLE
Update to DSL 10.5.1 and bundle 12.9.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -143,8 +143,8 @@
         <gpg.passphrase>configured-by-release-profile</gpg.passphrase>
         <stagingTimeoutInMinutes>20</stagingTimeoutInMinutes>
 
-        <rune.dsl.version>10.5.0</rune.dsl.version>
-        <rosetta.bundle.version>12.9.0</rosetta.bundle.version>
+        <rune.dsl.version>10.5.1</rune.dsl.version>
+        <rosetta.bundle.version>12.9.1</rosetta.bundle.version>
 
         <xtext.version>2.38.0</xtext.version>
         <guice.version>6.0.0</guice.version>


### PR DESCRIPTION
Picks up [rune-dsl 10.5.1](https://github.com/finos/rune-dsl/releases/tag/10.5.1) and sets the next bundle version to 12.9.1.

10.5.1 fixes the setup's Rune config wiring being dropped by any custom Xtext setup that overrides `createInjector()` ([#1355](https://github.com/finos/rune-dsl/pull/1355)) — including `CDMRosettaSetup` in this repo, which is what broke CDM's json-schema generation against rune-fpml 3.4.0.