### PR TITLE
[11.x.x] Update to DSL 9.88.1 and bundle 11.128.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -143,8 +143,8 @@
         <gpg.passphrase>configured-by-release-profile</gpg.passphrase>
         <stagingTimeoutInMinutes>20</stagingTimeoutInMinutes>
 
-        <rune.dsl.version>9.88.0</rune.dsl.version>
-        <rosetta.bundle.version>11.128.0</rosetta.bundle.version>
+        <rune.dsl.version>9.88.1</rune.dsl.version>
+        <rosetta.bundle.version>11.128.1</rosetta.bundle.version>
 
         <xtext.version>2.38.0</xtext.version>
         <guice.version>6.0.0</guice.version>


### PR DESCRIPTION
Picks up [rune-dsl 9.88.1](https://github.com/finos/rune-dsl/releases/tag/9.88.1), the 9.x.x backport of the fix for the setup's Rune config wiring being dropped by any custom Xtext setup that overrides `createInjector()` ([#1357](https://github.com/finos/rune-dsl/pull/1357)).

Also sets the next bundle version to 11.128.1.