### PR TITLE
chore: bundle 12.11.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -144,7 +144,7 @@
         <stagingTimeoutInMinutes>20</stagingTimeoutInMinutes>
 
         <rune.dsl.version>10.7.0</rune.dsl.version>
-        <rosetta.bundle.version>12.10.0</rosetta.bundle.version>
+        <rosetta.bundle.version>12.11.0</rosetta.bundle.version>
 
         <xtext.version>2.38.0</xtext.version>
         <guice.version>6.0.0</guice.version>


### PR DESCRIPTION
Next bundle version, a minor increment on the released 12.10.0.

No DSL bump: every bundle repo is already on `rune.dsl.version` 10.7.0, and 12.10.0 is tagged across all four.

What 12.11.0 picks up on the model-import side:

- [rosetta-components #902](https://github.com/REGnosys/rosetta-components/pull/902) — import config split into a format-agnostic `target` and per-format `options`
- [rosetta-components #903](https://github.com/REGnosys/rosetta-components/pull/903) — the CSV import options
- [rosetta-components #906](https://github.com/REGnosys/rosetta-components/pull/906) — `hasHeader` dropped, dialect defaulted to RFC 4180

## Test dispositions

One line, in `pom.xml`. A version bump has nothing to test; the bundle release itself is the verification, since every repo builds against this value.

Only the real `rosetta.bundle.version` moves — the profile-default `0.0.0.main-SNAPSHOT` self-version on line 85 is deliberately untouched.
