### PR TITLE
[11.x.x] Enable OSS Index analyzer in CVE scanning

### DIFF
--- a/.github/workflows/cve-scanning.yml
+++ b/.github/workflows/cve-scanning.yml
@@ -90,7 +90,9 @@ jobs:
             -Dformats=HTML \
             -DoutputDirectory=reports \
             -DfailBuildOnCVSS=7 \
-            -DossIndexAnalyzerEnabled=false \
+            -DossIndexAnalyzerEnabled=true \
+            -DossIndexUsername=${{ secrets.OSSINDEX_USERNAME }} \
+            -DossIndexPassword=${{ secrets.OSSINDEX_TOKEN }} \
             -DnodeAuditAnalyzerEnabled=false
       - name: Upload results
         if: always()


### PR DESCRIPTION
Enables the Sonatype OSS Index analyzer in the CVE scanning workflow

OSS Index reports vulnerabilities that are not yet in the NVD dataset, so this catches CVEs the current NVD-only scan misses (e.g. a very recently published CVE). `nodeAuditAnalyzerEnabled` is left disabled.

Needs `OSSINDEX_USERNAME`/`OSSINDEX_TOKEN` repo secrets to actually take effect — without them dependency-check silently disables the analyzer (no failure, just a no-op) per the [OWASP docs](https://dependency-check.github.io/DependencyCheck/analyzers/oss-index-analyzer.html). Please add those secrets if not already present.
