### PR TITLE
CVE scanning: Mon/Wed/Fri schedule, OSS_INDEX_* secrets, logback fix

### DIFF
--- a/.github/workflows/cve-scanning-schedule.yml
+++ b/.github/workflows/cve-scanning-schedule.yml
@@ -10,10 +10,10 @@ name: CVE Scanning Schedule
 # to diverge its own scanning logic independently.
 on:
   schedule:
-    # Run daily to catch newly published CVEs even without repo changes.
+    # Run Mon/Wed/Fri to catch newly published CVEs even without repo changes.
     # Scheduled after rune-dsl (01:00), rune-common (01:30) and rune-testing
     # (02:00) so scans don't all hit the NVD API / shared runners at once.
-    - cron: '30 2 * * *'
+    - cron: '30 2 * * 1,3,5'
 
 permissions:
   actions: write # Required to trigger cve-scanning.yml via the GitHub CLI

--- a/.github/workflows/cve-scanning.yml
+++ b/.github/workflows/cve-scanning.yml
@@ -91,8 +91,8 @@ jobs:
             -DoutputDirectory=reports \
             -DfailBuildOnCVSS=7 \
             -DossIndexAnalyzerEnabled=true \
-            -DossIndexUsername=${{ secrets.OSSINDEX_USERNAME }} \
-            -DossIndexPassword=${{ secrets.OSSINDEX_TOKEN }} \
+            -DossIndexUsername=${{ secrets.OSS_INDEX_USERNAME }} \
+            -DossIndexPassword=${{ secrets.OSS_INDEX_TOKEN }} \
             -DnodeAuditAnalyzerEnabled=false
       - name: Upload results
         if: always()
@@ -124,7 +124,7 @@ jobs:
             }" \
             "$SLACK_WEBHOOK_URL"
       # Also notify Slack on success for scheduled runs, so the team has
-      # positive confirmation that the daily scan is running and clean.
+      # positive confirmation that the scheduled scan is running and clean.
       - name: Notify Slack on scan success
         if: success() && inputs.scheduled == true
         env:

--- a/pom.xml
+++ b/pom.xml
@@ -154,7 +154,7 @@
 
         <!-- CVE fixes for transitive dependencies pulled in below their patched versions -->
         <commons-beanutils.version>1.11.0</commons-beanutils.version>
-        <jackson-databind.version>2.18.8</jackson-databind.version>
+        <jackson-databind.version>2.18.10</jackson-databind.version>
         <log4j-api.version>2.25.4</log4j-api.version>
         <plexus-utils.version>3.6.1</plexus-utils.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -150,7 +150,7 @@
         <guice.version>6.0.0</guice.version>
 
         <slf4j.version>2.0.13</slf4j.version>
-        <logback.version>1.5.6</logback.version>
+        <logback.version>1.5.38</logback.version>
 
         <!-- CVE fixes for transitive dependencies pulled in below their patched versions -->
         <commons-beanutils.version>1.11.0</commons-beanutils.version>


### PR DESCRIPTION
## Summary
- CVE scan schedule (`cve-scanning-schedule.yml`) now runs Mon/Wed/Fri at 02:30 UTC instead of daily.
- Renamed the OSS Index secrets referenced in `cve-scanning.yml` from `OSSINDEX_USERNAME`/`OSSINDEX_TOKEN` to `OSS_INDEX_USERNAME`/`OSS_INDEX_TOKEN` (matching rune-dsl/rune-common/rune-testing).
- Bumped `logback.version` 1.5.6 → 1.5.38, fixing CVE-2026-13006 (CVSS 7.0, arbitrary code execution via Janino-evaluated conditional expressions in logback config; 1.5.37 is the definitive fix).

## Test plan
- [x] `mvn test` passes with the bumped logback version
- [ ] Repo secrets `OSS_INDEX_USERNAME` and `OSS_INDEX_TOKEN` are added before/at merge (old `OSSINDEX_*` names can then be removed)