### PR TITLE
Remove the plexus-utils pin, which rune-common no longer needs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -156,7 +156,6 @@
         <commons-beanutils.version>1.11.0</commons-beanutils.version>
         <jackson-databind.version>2.18.10</jackson-databind.version>
         <log4j-api.version>2.25.4</log4j-api.version>
-        <plexus-utils.version>3.6.1</plexus-utils.version>
 
         <!-- test -->
         <junit.version>5.8.1</junit.version>
@@ -337,11 +336,6 @@
                 <groupId>org.apache.logging.log4j</groupId>
                 <artifactId>log4j-api</artifactId>
                 <version>${log4j-api.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.codehaus.plexus</groupId>
-                <artifactId>plexus-utils</artifactId>
-                <version>${plexus-utils.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
rune-common now excludes `maven-plugin-api` from its rune-maven-plugin dependency ([finos/rune-common#716](https://github.com/finos/rune-common/pull/716), [#717](https://github.com/finos/rune-common/pull/717)), so `plexus-utils` no longer reaches this project at all and the pin manages nothing. A pin that manages no dependency is worse than no pin: the next person reading it takes it for protection, which is how CVE-2025-67030 reached downstream consumers while the upstream scan stayed green.

Verified with `-P regnosys`, the profile both `check-pr` and the CVE scan use: `mvn dependency:tree -P regnosys` reports zero `plexus-utils` nodes with the pin removed. It needs the fixed rune-common snapshot in Artifact Registry, which the merges above publish.

Worth knowing for a release build: against the released bundle version this pom still names, removing the pin puts `plexus-utils` 3.6.0 back in 8 modules. So this wants the bundle bump of the coordinated release, not a release cut before it.

Part of removing the same pin across the projects released together. rune-testing and rosetta-components' bsp keep theirs, because their `plexus-utils` arrives through a direct `maven-artifact` dependency rather than through rune-common.

🤖 Generated with [Claude Code](https://claude.com/claude-code)