### PR TITLE
Update DSL version to 10.10.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -143,8 +143,8 @@
         <gpg.passphrase>configured-by-release-profile</gpg.passphrase>
         <stagingTimeoutInMinutes>20</stagingTimeoutInMinutes>
 
-        <rune.dsl.version>10.10.0</rune.dsl.version>
-        <rosetta.bundle.version>12.15.0</rosetta.bundle.version>
+        <rune.dsl.version>10.10.1</rune.dsl.version>
+        <rosetta.bundle.version>12.15.1</rosetta.bundle.version>
 
         <xtext.version>2.38.0</xtext.version>
         <guice.version>6.0.0</guice.version>


### PR DESCRIPTION
Bumps `rune.dsl.version` to [10.10.1](https://github.com/finos/rune-dsl/releases/tag/10.10.1) and sets the next bundle version to 12.15.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M45ugrJEvsE5997CtsRVbT