### PR TITLE
Update DSL version to 9.92.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -143,8 +143,8 @@
         <gpg.passphrase>configured-by-release-profile</gpg.passphrase>
         <stagingTimeoutInMinutes>20</stagingTimeoutInMinutes>
 
-        <rune.dsl.version>9.92.1</rune.dsl.version>
-        <rosetta.bundle.version>11.132.0</rosetta.bundle.version>
+        <rune.dsl.version>9.92.2</rune.dsl.version>
+        <rosetta.bundle.version>11.132.1</rosetta.bundle.version>
 
         <xtext.version>2.38.0</xtext.version>
         <guice.version>6.0.0</guice.version>


### PR DESCRIPTION
Bumps `rune.dsl.version` to [9.92.2](https://github.com/finos/rune-dsl/releases/tag/9.92.2) and sets the next bundle version to 11.132.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M45ugrJEvsE5997CtsRVbT