### PR TITLE
Update DSL version to 9.92.3 and set next bundle version to 11.132.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -143,8 +143,8 @@
         <gpg.passphrase>configured-by-release-profile</gpg.passphrase>
         <stagingTimeoutInMinutes>20</stagingTimeoutInMinutes>
 
-        <rune.dsl.version>9.92.2</rune.dsl.version>
-        <rosetta.bundle.version>11.132.1</rosetta.bundle.version>
+        <rune.dsl.version>9.92.3</rune.dsl.version>
+        <rosetta.bundle.version>11.132.5</rosetta.bundle.version>
 
         <xtext.version>2.38.0</xtext.version>
         <guice.version>6.0.0</guice.version>


### PR DESCRIPTION
Bumps the `rune.dsl.version` property to [9.92.3](https://github.com/finos/rune-dsl/releases/tag/9.92.3) on the 11.x bundle line.

It also moves `rosetta.bundle.version` from 11.132.1 to 11.132.5, which is a bigger jump than usual. Tags 11.132.1 through 11.132.4 already exist on all five bundle repos. The property had been left at 11.132.1 by the previous update line, so 11.132.5 is the next free version, not 11.132.2.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M45ugrJEvsE5997CtsRVbT
