### PR TITLE
Update DSL version to 10.11.0 and set next bundle version to 12.18.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -143,8 +143,8 @@
         <gpg.passphrase>configured-by-release-profile</gpg.passphrase>
         <stagingTimeoutInMinutes>20</stagingTimeoutInMinutes>
 
-        <rune.dsl.version>10.10.1</rune.dsl.version>
-        <rosetta.bundle.version>12.15.1</rosetta.bundle.version>
+        <rune.dsl.version>10.11.0</rune.dsl.version>
+        <rosetta.bundle.version>12.18.0</rosetta.bundle.version>
 
         <xtext.version>2.38.0</xtext.version>
         <guice.version>6.0.0</guice.version>


### PR DESCRIPTION
Update to Rune DSL 10.11.0 and set next bundle version to 12.18.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019sS8MzpfD3AdMiU3NPQprF
